### PR TITLE
feat: 教科書取得を site id 由来の lectureCode ベースに変更

### DIFF
--- a/background.js
+++ b/background.js
@@ -122,7 +122,7 @@ async function fetchAndDecode(url) {
 
 // /search エンドポイントで科目名を検索し、最適な lectureNo を返す
 // 全学部・全科目 (11,848件) が対象
-async function searchSyllabus(keyword) {
+async function searchSyllabus(keyword, preferFirstResult) {
   // サーバーがShift_JISエンコードを期待するため、encodeShiftJISを使用
   // x/y パラメータは <input type="image"> のsubmitボタン座標（必須）
   const searchUrl =
@@ -179,6 +179,16 @@ async function searchSyllabus(keyword) {
       "[KULMS] results:",
       results.map((r) => r.name).join(", ")
     );
+  }
+
+  if (preferFirstResult) {
+    console.log(
+      "[KULMS] using first result for keyword:",
+      keyword,
+      results[0].name,
+      results[0].lectureNo
+    );
+    return { lectureNo: results[0].lectureNo, departmentNo: results[0].departmentNo };
   }
 
   const normalized = normalizeForMatch(keyword);
@@ -344,19 +354,34 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action !== "fetchTextbooks") return false;
 
   const courseName = message.courseName;
-  if (!courseName) {
+  const lectureCode = String(message.lectureCode || "").trim().toUpperCase();
+  if (!courseName && !lectureCode) {
     sendResponse({ books: [] });
     return false;
   }
 
-  const keyword = cleanCourseName(courseName);
-  if (!keyword) {
+  const keyword = cleanCourseName(courseName || "");
+  if (!lectureCode && !keyword) {
     sendResponse({ books: [] });
     return false;
   }
 
   (async () => {
     try {
+      if (lectureCode) {
+        const matched = await searchSyllabus(lectureCode, true);
+        if (!matched) {
+          sendResponse({ books: [] });
+          return;
+        }
+        const syllabusUrl = matched.departmentNo
+          ? `${SYLLABUS_BASE}/department_syllabus?lectureNo=${matched.lectureNo}&departmentNo=${matched.departmentNo}`
+          : `${SYLLABUS_BASE}/la_syllabus?lectureNo=${matched.lectureNo}`;
+        const books = await fetchSyllabusDetail(matched.lectureNo, matched.departmentNo);
+        sendResponse({ books, syllabusUrl });
+        return;
+      }
+
       const result = await searchSyllabus(keyword);
       if (!result) {
         sendResponse({ books: [] });

--- a/safari/KULMS+ Extension/Resources/background.js
+++ b/safari/KULMS+ Extension/Resources/background.js
@@ -122,7 +122,7 @@ async function fetchAndDecode(url) {
 
 // /search エンドポイントで科目名を検索し、最適な lectureNo を返す
 // 全学部・全科目 (11,848件) が対象
-async function searchSyllabus(keyword) {
+async function searchSyllabus(keyword, preferFirstResult) {
   // サーバーがShift_JISエンコードを期待するため、encodeShiftJISを使用
   // x/y パラメータは <input type="image"> のsubmitボタン座標（必須）
   const searchUrl =
@@ -179,6 +179,16 @@ async function searchSyllabus(keyword) {
       "[KULMS] results:",
       results.map((r) => r.name).join(", ")
     );
+  }
+
+  if (preferFirstResult) {
+    console.log(
+      "[KULMS] using first result for keyword:",
+      keyword,
+      results[0].name,
+      results[0].lectureNo
+    );
+    return { lectureNo: results[0].lectureNo, departmentNo: results[0].departmentNo };
   }
 
   const normalized = normalizeForMatch(keyword);
@@ -344,19 +354,34 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action !== "fetchTextbooks") return false;
 
   const courseName = message.courseName;
-  if (!courseName) {
+  const lectureCode = String(message.lectureCode || "").trim().toUpperCase();
+  if (!courseName && !lectureCode) {
     sendResponse({ books: [] });
     return false;
   }
 
-  const keyword = cleanCourseName(courseName);
-  if (!keyword) {
+  const keyword = cleanCourseName(courseName || "");
+  if (!lectureCode && !keyword) {
     sendResponse({ books: [] });
     return false;
   }
 
   (async () => {
     try {
+      if (lectureCode) {
+        const matched = await searchSyllabus(lectureCode, true);
+        if (!matched) {
+          sendResponse({ books: [] });
+          return;
+        }
+        const syllabusUrl = matched.departmentNo
+          ? `${SYLLABUS_BASE}/department_syllabus?lectureNo=${matched.lectureNo}&departmentNo=${matched.departmentNo}`
+          : `${SYLLABUS_BASE}/la_syllabus?lectureNo=${matched.lectureNo}`;
+        const books = await fetchSyllabusDetail(matched.lectureNo, matched.departmentNo);
+        sendResponse({ books, syllabusUrl });
+        return;
+      }
+
       const result = await searchSyllabus(keyword);
       if (!result) {
         sendResponse({ books: [] });

--- a/safari/KULMS+ Extension/Resources/src/textbooks.js
+++ b/safari/KULMS+ Extension/Resources/src/textbooks.js
@@ -6,9 +6,17 @@
   if (window !== window.top) return;
   if (window.__kulmsSettings && window.__kulmsSettings.textbooks === false) return;
 
-  const TEXTBOOK_CACHE_KEY = "kulms-textbooks";
+  const TEXTBOOK_CACHE_KEY = "kulms-textbooks-v2";
   // キャッシュは無期限 (更新ボタンで手動リフレッシュ)
   const BASE_URL = window.location.origin;
+
+  function extractLectureCodeFromSiteId(siteId) {
+    if (!siteId) return "";
+    var parts = String(siteId).split("-");
+    if (parts.length < 3) return "";
+    var lectureCode = parts.slice(2).join("").trim();
+    return /^[A-Za-z0-9]+$/.test(lectureCode) ? lectureCode.toUpperCase() : "";
+  }
 
   // --- コース一覧取得 ---
   // Sakai APIを優先（正確なコース名・タイプを返す）
@@ -21,7 +29,11 @@
     const data = await res.json();
     return (data.site_collection || [])
       .filter((s) => s.type === "course" || s.type === "project")
-      .map((s) => ({ id: s.id, name: s.title }));
+      .map((s) => ({
+        id: s.id,
+        name: s.title,
+        lectureCode: extractLectureCodeFromSiteId(s.id),
+      }));
   }
 
   function extractCoursesFromDOM() {
@@ -39,7 +51,11 @@
         if (/\/tool\//.test(href)) return;
         var match = href.match(/\/portal\/site\/([^\/?#]+)/);
         if (match && !match[1].startsWith("~")) {
-          courses.push({ id: match[1], name: a.textContent.trim() });
+          courses.push({
+            id: match[1],
+            name: a.textContent.trim(),
+            lectureCode: extractLectureCodeFromSiteId(match[1]),
+          });
         }
       });
     var seen = new Set();
@@ -84,10 +100,14 @@
 
   // --- background へリクエスト ---
 
-  function fetchTextbooksForCourse(courseName) {
+  function fetchTextbooksForCourse(course) {
     return new Promise((resolve) => {
       chrome.runtime.sendMessage(
-        { action: "fetchTextbooks", courseName: courseName },
+        {
+          action: "fetchTextbooks",
+          courseName: course.name,
+          lectureCode: course.lectureCode || "",
+        },
         (response) => {
           if (chrome.runtime.lastError) {
             resolve([]);
@@ -303,7 +323,8 @@
 
       var allTextbooks = {};
       for (var i = 0; i < courses.length; i++) {
-        var name = courses[i].name;
+        var course = courses[i];
+        var name = course.name;
         showLoading(
           "\u30B7\u30E9\u30D0\u30B9\u3092\u53D6\u5F97\u4E2D... (" +
             (i + 1) +
@@ -312,7 +333,7 @@
             ")"
         );
         try {
-          var result = await fetchTextbooksForCourse(name);
+          var result = await fetchTextbooksForCourse(course);
           if (result.books.length > 0) {
             allTextbooks[name] = { books: result.books, syllabusUrl: result.syllabusUrl, status: "found" };
           } else {

--- a/src/textbooks.js
+++ b/src/textbooks.js
@@ -6,9 +6,17 @@
   if (window !== window.top) return;
   if (window.__kulmsSettings && window.__kulmsSettings.textbooks === false) return;
 
-  const TEXTBOOK_CACHE_KEY = "kulms-textbooks";
+  const TEXTBOOK_CACHE_KEY = "kulms-textbooks-v2";
   // キャッシュは無期限 (更新ボタンで手動リフレッシュ)
   const BASE_URL = window.location.origin;
+
+  function extractLectureCodeFromSiteId(siteId) {
+    if (!siteId) return "";
+    var parts = String(siteId).split("-");
+    if (parts.length < 3) return "";
+    var lectureCode = parts.slice(2).join("").trim();
+    return /^[A-Za-z0-9]+$/.test(lectureCode) ? lectureCode.toUpperCase() : "";
+  }
 
   // --- コース一覧取得 ---
   // Sakai APIを優先（正確なコース名・タイプを返す）
@@ -21,7 +29,11 @@
     const data = await res.json();
     return (data.site_collection || [])
       .filter((s) => s.type === "course" || s.type === "project")
-      .map((s) => ({ id: s.id, name: s.title }));
+      .map((s) => ({
+        id: s.id,
+        name: s.title,
+        lectureCode: extractLectureCodeFromSiteId(s.id),
+      }));
   }
 
   function extractCoursesFromDOM() {
@@ -39,7 +51,11 @@
         if (/\/tool\//.test(href)) return;
         var match = href.match(/\/portal\/site\/([^\/?#]+)/);
         if (match && !match[1].startsWith("~")) {
-          courses.push({ id: match[1], name: a.textContent.trim() });
+          courses.push({
+            id: match[1],
+            name: a.textContent.trim(),
+            lectureCode: extractLectureCodeFromSiteId(match[1]),
+          });
         }
       });
     var seen = new Set();
@@ -84,10 +100,14 @@
 
   // --- background へリクエスト ---
 
-  function fetchTextbooksForCourse(courseName) {
+  function fetchTextbooksForCourse(course) {
     return new Promise((resolve) => {
       chrome.runtime.sendMessage(
-        { action: "fetchTextbooks", courseName: courseName },
+        {
+          action: "fetchTextbooks",
+          courseName: course.name,
+          lectureCode: course.lectureCode || "",
+        },
         (response) => {
           if (chrome.runtime.lastError) {
             resolve([]);
@@ -303,7 +323,8 @@
 
       var allTextbooks = {};
       for (var i = 0; i < courses.length; i++) {
-        var name = courses[i].name;
+        var course = courses[i];
+        var name = course.name;
         showLoading(
           "\u30B7\u30E9\u30D0\u30B9\u3092\u53D6\u5F97\u4E2D... (" +
             (i + 1) +
@@ -312,7 +333,7 @@
             ")"
         );
         try {
-          var result = await fetchTextbooksForCourse(name);
+          var result = await fetchTextbooksForCourse(course);
           if (result.books.length > 0) {
             allTextbooks[name] = { books: result.books, syllabusUrl: result.syllabusUrl, status: "found" };
           } else {


### PR DESCRIPTION
## 概要
教科書・参考書の取得フローを変更し、Sakai API `/direct/site.json` の各 `site.id` から `lectureCode` を抽出して公開シラバス検索に利用するように。

## 変更内容
- `site_collection` の各要素の `id` から `lectureCode` を抽出
  - 例: `2026-888-H352-001` -> `H352001`
- 教科書取得時に `lectureCode` を background に渡すよう変更
- `lectureCode` がある場合は
  - `https://www.k.kyoto-u.ac.jp/external/open_syllabus/search?condition.keyword=...`
  - を使って公開シラバスを検索
  - 検索結果の先頭を採用して詳細ページを取得
- `lectureCode` が取れない場合は従来の科目名検索にフォールバック
- 既存キャッシュと衝突しないよう教科書キャッシュキーを更新

## 背景
当初は `student/la/syllabus/detail?condition.lectureCode=...` の直接利用を検討したが、ログイン認証が必要だったため、認証不要な `external/open_syllabus/search` を使う方式に。

## 影響範囲
- 教科書パネルのシラバス取得処理
- Chrome 版 / Safari 版の両方

## 動作確認
手元の最新Chrome環境(Mac OS)で #7 の 問題が解決したことを確認しました。
