### PR TITLE
Throw generic error for non-JSON API responses

### DIFF
--- a/safari/KULMS+ Extension/Resources/src/assignments.js
+++ b/safari/KULMS+ Extension/Resources/src/assignments.js
@@ -58,7 +58,10 @@
     }
     const ct = res.headers.get("content-type") || "";
     if (ct && ct.indexOf("json") === -1) {
-      throw LoggedOutError();
+      if (/\/portal\/(x?login|relogin|logout)/.test(res.url)) {
+        throw LoggedOutError();
+      }
+      throw new Error(`API ${path} returned non-JSON (status ${res.status})`);
     }
     if (!res.ok) {
       throw new Error(`API ${path} returned ${res.status}`);

--- a/src/assignments.js
+++ b/src/assignments.js
@@ -58,7 +58,8 @@
     }
     const ct = res.headers.get("content-type") || "";
     if (ct && ct.indexOf("json") === -1) {
-      throw LoggedOutError();
+      // throw LoggedOutError();
+      throw new Error(`API ${path} returned ${res.status}`);
     }
     if (!res.ok) {
       throw new Error(`API ${path} returned ${res.status}`);

--- a/src/assignments.js
+++ b/src/assignments.js
@@ -58,8 +58,10 @@
     }
     const ct = res.headers.get("content-type") || "";
     if (ct && ct.indexOf("json") === -1) {
-      // throw LoggedOutError();
-      throw new Error(`API ${path} returned ${res.status}`);
+      if (/\/portal\/(x?login|relogin|logout)/.test(res.url)) {
+        throw LoggedOutError();
+      }
+      throw new Error(`API ${path} returned non-JSON (status ${res.status})`);
     }
     if (!res.ok) {
       throw new Error(`API ${path} returned ${res.status}`);


### PR DESCRIPTION
Replace the previous LoggedOutError thrown when an API response had a non-JSON content-type with a generic Error that includes the request path and response status. This provides clearer diagnostics for unexpected content-type responses in src/assignments.js (the original LoggedOutError line was commented out).

#41 の修正です